### PR TITLE
Remove redundant Return 0 from within loop

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -258,7 +258,6 @@ function FindGroupByMember(src)
                         return group
                     end
                 end
-                return 0
             end
         end
     else


### PR DESCRIPTION
# Issue with Returning Group ID in 'FindGroupByMember' Function

## Problem Description
The `FindGroupByMember` function incorrectly returns 0 for players who are not part of the first indexed group in the 'Groups' array. This issue affects the functionality when a player, who belongs to any group other than the first has their ID fetched.

## Example Scenario
- Consider the following simplified representation of the 'Groups' variable (omitting 'members'/'leader' keys)

  ```lua
  Groups = [
    1: 1,
    2: 2,
    3: 3, 4
    4: 5
  ]

In this structure, when Player ID 4 from Group 3 enters a zone to complete a job, and I call `exports["ps-playergroups"]:FindGroupByMember(src)`, it incorrectly returns 0 instead of 3.

## Why Does It Return 0 Instead of the Correct Group ID?

Initially, I spent a couple of hours debugging my code before realizing the function was returning 0 prematurely. The issue arises because the function, upon failing to find the player as a leader or a helper in the first group, immediately returns 0. This behavior prevents the function from checking subsequent groups.

## Testing and Replication
- I set up a test environment with 3 players, each creating an independent group.
- Observing the 'Groups' variable, I tracked its updates as groups were formed and disbanded.
- When Group 2 attempted to complete their job, the function erroneously returned Group ID 0 instead of 2.
- Group 1, being the first in the array, successfully completed their job as the function returned the correct Group ID 1.
- After Group 1 disbanded, Group 2 was still unable to complete their job due to the same issue.
- Only after Group 1 was completely removed from the 'Groups' array (by disbanding their group) did the function start returning the correct Group ID for - Group 2.

I am surprised this issue was not identified earlier, given its potential impact on gameplay.